### PR TITLE
Change order of collision and player update

### DIFF
--- a/LevelManager.java
+++ b/LevelManager.java
@@ -75,11 +75,11 @@ public class LevelManager {
             // gamePanel.startGame(); //Uncomment this for a good time ;)
             return;
         }
-        handlePlayerInput(keys);
-        player.update(); //use this to update the player for things that the user does not directly control, such as increasing time for drawing a cape blowing
-        
+
         collisionManager.checkCollisions(keys);
 
+        player.update(); //use this to update the player for things that the user does not directly control, such as increasing time for drawing a cape blowing
+        handlePlayerInput(keys);        
         // for (int i = 0; i < gameEntities.size(); i++) {
         // for (GameEntity entity : gameEntities) {
         Iterator<GameEntity> iterator = gameEntities.iterator();


### PR DESCRIPTION
Require a change to the order of operations in LevelManager's update.

Following the pattern of the enemies I've written, KnifePlayer (and subsequent Player types) should call `stopAttack()` at the start of their update. The intended effect is:
- In some frame `attack()` is called
- The collisionManger handles the collision logic
- The very next frame, Player calls `stopAttack()`

This way, I can control the timing and duration of attacks as necessary within each Character subclass, and ensure that only one instance of damage is dealt for every attack (as opposed to damage being dealt for multiple frames, which quickly balloons uncontrollably). 

This worked fine for Enemies, because their updates are all handled after collisionManager checks collisions. In other words, collisionManager can check their collisions the moment before they update and call `stopAttack()`.
Currently, Player's update occurs before collisionManager, which means collisionManager never sees the moment that Player is attacking (since Player should call `stopAttack()` on every update).

Also, `handlePlayerInputs` has to occur after Player's update because player's `attack()` is called within `handlePlayerInputs`. As it is right now, whenever Player attacks, their update would immediately stop the attack, meaning again that collisionManager would not see it.

I think these changes don't really affect the balance or fairness of inputs, and makes my writing more comfortable