### PR TITLE
Stopped enemies moving off-map

### DIFF
--- a/LevelManager.java
+++ b/LevelManager.java
@@ -169,7 +169,7 @@ public class LevelManager {
                 entity.update();
                 
                 if (entity instanceof Enemy)
-                    restrictToMapBoundaries((entity);
+                    restrictToMapBoundaries((entity));
             }
         }
     }


### PR DESCRIPTION
Added function to ensure Game Entity is within MapBoundary; only called on Enemies in LevelManager's update.